### PR TITLE
Make ground truth file optional in descriptor eval

### DIFF
--- a/descriptor_eval.py
+++ b/descriptor_eval.py
@@ -26,9 +26,7 @@ parser.add_argument(
     help="Path to write candidates (optional)",
     type=str,
 )
-parser.add_argument(
-    "--ground_truth", help="Path containing Groundtruth", type=str, required=True
-)
+parser.add_argument("--ground_truth", help="Path containing Groundtruth", type=str)
 
 
 logging.basicConfig(


### PR DESCRIPTION
In [descriptor_eval.py](https://github.com/facebookresearch/vsc2022/blob/facfa0201540574708b2df6c6c31ad4452ed4b97/descriptor_eval.py), a ground truth file is currently required which generates a score and various scoring assets like a precision-recall curve. In the [descriptor runtime environment](https://github.com/drivendataorg/meta-vsc-descriptor-runtime), participants will not be provided with a ground truth file.

This PR adapts the descriptor evaluation script and corresponding library file to make the ground truth file an optional argument rather than required, enabling the use of this script to generate a candidate rankings csv file of query-ref pairs with a score.