### PR TITLE
Update docs with correct accelerator signature

### DIFF
--- a/docs/baseline.md
+++ b/docs/baseline.md
@@ -72,7 +72,7 @@ training dataset, so do inference on that dataset too.
 
 ```
 python -m vsc.baseline.inference \
-    --accelerator gpu --processes 2 \
+    --accelerator cuda --processes 2 \
     --torchscript_path ./sscd_disc_mixup.no_l2_norm.torchscript.pt \
     --output_file ./output/validation_refs.npz \
     --dataset_path ./validation_dataset/refs


### PR DESCRIPTION
Closes #3 

This PR changes the baseline docs to use `--accelerator cuda` instead of `--accelerator gpu`.

Potential alternative would be to change `CUDA = enum.auto()` to `GPU = enum.auto()`