### PR TITLE
Remove unnecessary intermediate calculations from matching metric

### DIFF
--- a/vsc/metrics.py
+++ b/vsc/metrics.py
@@ -344,13 +344,13 @@ def match_metric(
             intersection_deltas, total_deltas = video_pairs[
                 prediction.pair_id()
             ].add_prediction(prediction)
-            recalls = {}
-            precisions = {}
             for axis in Axis:
                 # Accumulate the differences to the corresponding values
                 intersections[axis] += intersection_deltas[axis]
                 totals[axis] += total_deltas[axis]
 
+        recalls = {}
+        precisions = {}
         for axis in Axis:
             recalls[axis] = intersections[axis] / gt_total_lengths[axis]
             precisions[axis] = intersections[axis] / totals[axis]


### PR DESCRIPTION
This PR makes a small change to the metric calculation, removing the potentially unnecessary updates to precision and recall from within the loop calculating scores within a prediction group. All tests still passing, mostly a cosmetic change for clarity and very slight efficiency.